### PR TITLE
look for tokens as parameters as well

### DIFF
--- a/app/openbel/api/middleware/auth.rb
+++ b/app/openbel/api/middleware/auth.rb
@@ -16,8 +16,9 @@ module OpenBEL
     def self.check_cookie(env)
       cookie_hdr = env['HTTP_COOKIE']
       auth_hdr = env['HTTP_AUTHORIZATION']
-      if cookie_hdr.nil? and auth_hdr.nil?
-        raise 'missing authorization cookie/header'
+      token_param = params['token']
+      if cookie_hdr.nil? and auth_hdr.nil? and token_param.nil?
+        raise 'missing authorization cookie, header, or parameter'
       end
 
       if not cookie_hdr.nil?
@@ -42,6 +43,10 @@ module OpenBEL
         if token.nil?
           raise 'missing authorization header'
         end
+      end
+
+      if not token_param.nil?
+          token = token_param
       end
 
       secret = OpenBEL::Settings[:auth][:secret]


### PR DESCRIPTION
@abargnesi Attempting a quick patch to support JWT tokens as parameters for @wshayes - not sure if Rack's request params are available to middleware though.