### PR TITLE
use /data as mounted volume for RDF data

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -28,7 +28,6 @@ services:
       - "9292:9292"
     volumes:
       - .:/app
-      - ./data/rdf-resources:/data/rdf_resources
-      - ./data/rdf-store:/data/rdf_store
       - ./config:/config
+      - ./data:/data
     restart: always


### PR DESCRIPTION
mounting one directory for the RDF data allows both the db file and
rdf store directory to be available. previously the db file mounted
as a directory which resulted in an empty directory.

this explains the experience with empty namespace prefixes since the
db file did not contain any namespaces.